### PR TITLE
test that all notebooks have titles

### DIFF
--- a/__tests__/manifest.js
+++ b/__tests__/manifest.js
@@ -1,0 +1,9 @@
+const examples = require("..");
+
+it("has titles for every notebook and each title is 6 characters or more", () => {
+  examples.manifest.forEach(collection => {
+    collection.files.forEach(fileInfo => {
+      expect(fileInfo.metadata.title).toMatch(/.{6,}/);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "build": "node generate-manifest.js",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:conformance && npm run build",
-    "test:conformance": "node scripts/conformance.js"
+    "test": "npm run test:conformance && npm run build && npm run test:unit",
+    "test:conformance": "node scripts/conformance.js",
+    "test:unit": "jest"
   },
   "publishConfig": {
     "access": "public"
@@ -35,6 +36,7 @@
   "homepage": "https://github.com/nteract/examples#readme",
   "devDependencies": {
     "glob": "^7.1.3",
+    "jest": "^23.5.0",
     "jsonschema": "^1.2.4",
     "nbschema": "^0.1.0"
   }


### PR DESCRIPTION
* Sets up jest
* Ensures every notebook has a title attribute

On some level it would be nice if we could warn instead of failing, that way it's still easy for new contributors to add notebooks (since we can add the title after). This works for now though since Desktop is reliant on the title and makes it so people don't have to modify desktop to get notebooks in. 😄 