### PR TITLE
generate typescript definitions for our manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ ENV/
 node_modules
 
 manifest.json
+
+index.d.ts

--- a/generate-manifest.js
+++ b/generate-manifest.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-// console.log(__dirname)
 const path = require("path");
 
 const languages = ["r", "python", "node.js"];

--- a/generate-types.js
+++ b/generate-types.js
@@ -1,0 +1,31 @@
+const util = require("util");
+const writeFile = util.promisify(require("fs").writeFile);
+const readFile = util.promisify(require("fs").readFile);
+
+const { json2ts } = require("json-ts");
+const { format } = require("prettier");
+
+async function main() {
+  const manifestRaw = await readFile("manifest.json");
+
+  const manifestNamespace = json2ts(manifestRaw, {
+    rootName: "Manifest",
+    prefix: ""
+  });
+
+  const typeScriptDefinition = format(
+    `
+  ${manifestNamespace}
+
+  declare module '@nteract/examples' {
+    const manifest: Manifest;
+    export = manifest;
+  }
+  `,
+    { parser: "typescript" }
+  );
+
+  await writeFile("index.d.ts", typeScriptDefinition);
+}
+
+main();

--- a/generate-types.js
+++ b/generate-types.js
@@ -8,17 +8,18 @@ const { format } = require("prettier");
 async function main() {
   const manifestRaw = await readFile("manifest.json");
 
-  const manifestNamespace = json2ts(manifestRaw, {
-    rootName: "Manifest",
+  const rootName = "Manifest";
+  const manifestTypes = json2ts(manifestRaw, {
+    rootName,
     prefix: ""
   });
 
   const typeScriptDefinition = format(
     `
-  ${manifestNamespace}
-
   declare module '@nteract/examples' {
-    const manifest: Manifest;
+    ${manifestTypes}
+
+    const manifest: ${rootName};
     export = manifest;
   }
   `,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Example Jupyter notebooks for nteract",
   "main": "index.js",
   "scripts": {
-    "build": "node generate-manifest.js",
+    "build": "npm run generate:manifest && npm run generate:types",
+    "generate:manifest": "node generate-manifest.js",
+    "generate:types": "node generate-types.js",
     "prepublishOnly": "npm run build",
     "test": "npm run test:conformance && npm run build && npm run test:unit",
     "test:conformance": "node scripts/conformance.js",
@@ -18,6 +20,7 @@
     "url": "git+https://github.com/nteract/examples.git"
   },
   "files": [
+    "index.d.ts",
     "manifest.json",
     "python",
     "node.js",
@@ -37,7 +40,9 @@
   "devDependencies": {
     "glob": "^7.1.3",
     "jest": "^23.5.0",
+    "json-ts": "^1.6.4",
     "jsonschema": "^1.2.4",
-    "nbschema": "^0.1.0"
+    "nbschema": "^0.1.0",
+    "prettier": "^1.15.3"
   }
 }


### PR DESCRIPTION
This generates typescript definitions and prettifies them before publish.

Output:

```typescript
declare module "@nteract/examples" {
  type Manifest = ManifestItem[];
  interface ManifestItem {
    language: string;
    files: FilesItem[];
  }
  interface FilesItem {
    path: string;
    metadata: Metadata;
  }
  interface Metadata {
    kernel_info: Kernel_info;
    kernelspec: Kernelspec;
    language_info: Language_info;
    title: string;
    nteract: Nteract;
    "anaconda-cloud"?: {};
    LICENSE?: string;
  }
  interface Kernel_info {
    name: string;
  }
  interface Kernelspec {
    name: string;
    language: string;
    display_name: string;
  }
  interface Language_info {
    name: string;
    codemirror_mode?: string | Codemirror_mode;
    pygments_lexer?: string;
    mimetype: string;
    file_extension: string;
    version: string;
    nbconvert_exporter?: string;
  }
  interface Nteract {
    version: string;
  }
  interface Codemirror_mode {
    name: string;
    version: number;
  }

  const manifest: Manifest;
  export = manifest;
}
```