### PR TITLE
fix the manifest definition

### DIFF
--- a/generate-types.js
+++ b/generate-types.js
@@ -19,8 +19,7 @@ async function main() {
   declare module '@nteract/examples' {
     ${manifestTypes}
 
-    const manifest: ${rootName};
-    export = manifest;
+    export const manifest: ${rootName};
   }
   `,
     { parser: "typescript" }


### PR DESCRIPTION
Oops. I don't know why I made the manifest be _the_ export when `index.js` exports it on the `manifest` property. ._______.