### PR TITLE
Fix for the https://github.com/nteract/examples/issues/34

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - pandas
   - plotly
+  - chart-studio
   - requests
   - seaborn
   - traitlets

--- a/python/plotly.ipynb
+++ b/python/plotly.ipynb
@@ -169,7 +169,7 @@
    },
    "outputs": [],
    "source": [
-    "import plotly.plotly as py\n",
+    "import chart_studio.plotly as py\n",
     "import plotly.graph_objs as go\n",
     "\n",
     "import pandas as pd\n",


### PR DESCRIPTION
Update the notebook module from plotly.plotly to chart_studio as the prior already deprecated.

#34 